### PR TITLE
13.3.1 - Grammar version 3 on Antlr 4.13.1 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ A parser for [TOML](https://toml.io/en/) files with minimum dependencies.
 <dependency>
     <groupId>net.vieiro</groupId>
     <artifactId>toml-java</artifactId>
-    <version>2.13.1</version>
+    <version>13.3.1</version>
 </dependency>
 ```
 
 ```
-implementation 'net.vieiro:toml-java:2.13.1'
+implementation 'net.vieiro:toml-java:13.3.1'
 ```
 
 ## Basic usage
@@ -201,10 +201,20 @@ This version depends on Antlr4 v4.11.1 (changed to adhere to NetBeans Antlr4 ver
 
 ## 2.13.1 Antlr4 Lexer & Parser
 
-- Changed versioning schema. Major: Grammar version, Minor: Antlr4 version, Patch: bug fixes. (e.g. 2.13.1 means Grammar version 2, Antlr 4.13.X, Release 1)
+- Changed versioning scheme. Major: Grammar version, Minor: Antlr4 version, Patch: bug fixes. (e.g. 2.13.1 means Grammar version 2, Antlr 4.13.X, Release 1)
 - The Antlr4 lexer and parser is now considered a public API.
 - Updated the lexer to work nicely with unclosed literal strings (for NetBeans IDE Editor integration).
 - Upgraded Antlr4 runtime to v4.13.1 again.
 - Simple query language now ignores contiguous or leading spaces (this is, the following queries are equivalent: "/a/b", "a/b", "a//b").
-- Added "subtree" queries
+- Added "subtree" queries, to ease analyzing subtrees.
+
+## 13.3.1 
+
+- Changed versioning scheme to:
+    - Major: antlr version (for instance, `13` means `Antlr 4.13.X`
+    - Minor: toml-java grammar version.
+    - Patch: bug fixes
+- The lexer now detects incomplete tokens and properly reports them with token `INVALID_VALUE`.
+    - This is useful for the NetBeans Antlr bridge.
+- toml-java runs 555 unit tests.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.vieiro</groupId>
     <artifactId>toml-java</artifactId>
-    <version>2.13.2-SNAPSHOT</version>
+    <version>13.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>toml-java</name>
@@ -82,6 +82,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <version.antlr>4.13.1</version.antlr>
     </properties>
 
     <dependencies>
@@ -89,7 +90,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.13.1</version>
+            <version>${version.antlr}</version>
         </dependency>
         <!-- test dependencies below -->
         <dependency>
@@ -202,7 +203,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.11.1</version>
+                <version>${version.antlr}</version>
                 <executions>
                     <execution>
                         <id>antlr</id>

--- a/src/main/java/net/vieiro/toml/TOMLVisitor.java
+++ b/src/main/java/net/vieiro/toml/TOMLVisitor.java
@@ -128,7 +128,7 @@ final class TOMLVisitor implements ANTLRErrorListener, TOMLAntlrParserVisitor<Ob
     // AntlrErrorListener
     @Override
     public void syntaxError(Recognizer<?, ?> rcgnzr, Object o, int line, int col, String message, RecognitionException re) {
-        String error = String.format("Syntax error at %d:%d %s", line, col, message);
+        String error = String.format("%d:%d Syntax error %s", line, col, message);
         errors.add(error);
     }
 

--- a/src/test/java/net/vieiro/toml/TOMLStringTest.java
+++ b/src/test/java/net/vieiro/toml/TOMLStringTest.java
@@ -29,7 +29,7 @@ public class TOMLStringTest {
         System.out.println("testShouldDetectUnclosedStringsProperly");
         TOML toml = Util.parse("unclosed_literal.toml", false, true);
         assertFalse(toml.errors.isEmpty());
-        assertEquals(4, toml.errors.size());
+        assertEquals(3, toml.errors.size());
     }
 
     @Test

--- a/src/test/java/net/vieiro/toml/Util.java
+++ b/src/test/java/net/vieiro/toml/Util.java
@@ -15,6 +15,7 @@
  */
 package net.vieiro.toml;
 
+import java.io.ByteArrayOutputStream;
 import net.vieiro.toml.antlr4.TOMLAntlrLexer;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.Token;
@@ -47,7 +48,7 @@ public final class Util {
                 String literalName = lexer.getVocabulary().getLiteralName(tokenType);
                 String symbolName = lexer.getVocabulary().getSymbolicName(tokenType);
                 System.out.format("%-20s : %s%n", symbolName, token.getText().replace("\n", "\\n"));
-            } while(true);
+            } while (true);
         }
     }
 
@@ -76,6 +77,30 @@ public final class Util {
 
             return toml;
         }
+    }
+
+    /**
+     * Reads a resource as a String
+     *
+     * @param resource The name of the resource
+     * @return The content
+     */
+    public static String read(String resource) throws IOException {
+        byte[] buffer = new byte[16 * 2024];
+        String result;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream(16 * 2024)) {
+            try (InputStream input = Util.class.getResourceAsStream(resource)) {
+                while (true) {
+                    int n = input.read(buffer);
+                    if (n < 0) {
+                        break;
+                    }
+                    bos.write(buffer, 0, n);
+                }
+            }
+            result = new String(bos.toByteArray(), StandardCharsets.UTF_8);
+        }
+        return result;
     }
 
 }

--- a/src/test/java/net/vieiro/toml/lexer/TOMLLexerTest.java
+++ b/src/test/java/net/vieiro/toml/lexer/TOMLLexerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Antonio <antonio@vieiro.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.vieiro.toml.lexer;
+
+import net.vieiro.toml.*;
+import java.io.IOException;
+import java.util.BitSet;
+import net.vieiro.toml.antlr4.TOMLAntlrLexer;
+import org.antlr.v4.runtime.ANTLRErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class TOMLLexerTest {
+
+    private static final String string_repeat(char c, int n) {
+        if (n <= 0) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * The NetBeans Antlr lexing bridge requires that Antlr Lexers behave
+     * properly even on errors (unclosed strings, etc.).
+     *
+     * We do this adding extra Lexer rules that detect incomplete tokens and
+     * mark these as "INVALID_VALUE". The parser is then responsible for
+     * generating errors for these unexpected tokens.
+     *
+     * This test opens a (possibly invalid) TOML file, and then starts removing
+     * one character at a time (simulating a person editing a file). The lexer
+     * should be have properly (generating INVALID_VALUE tokens) at all times.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testShouldLexerBehaveProperlyOnErrors() throws IOException {
+        System.out.println("testShouldLexerBehaveProperlyOnErrors");
+
+        // Given the "arrow-parquet-Cargo.toml" input string
+        String input = Util.read("toml-lexer-test.toml");
+
+        for (StringBuilder sb = new StringBuilder(input); sb.length() > 0; sb.deleteCharAt(sb.length() - 1)) {
+            String toParse = sb.toString();
+            String[] lines = toParse.split("\n");
+            TOMLAntlrLexer lexer = new TOMLAntlrLexer(CharStreams.fromString(toParse));
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(new ANTLRErrorListener() {
+                @Override
+                public void syntaxError(Recognizer<?, ?> rcgnzr, Object o, int lineNumber,
+                        int columnNumber, String message, RecognitionException re) {
+                    System.err.format("Error at %d:%d:%s%n", lineNumber, columnNumber, message);
+                    System.err.format("%d: |%s|%n", lineNumber, lines[lineNumber - 1]);
+                    System.err.format("%d:  %s^%n", lineNumber, string_repeat(' ', columnNumber));
+                    fail("Lexer should detect an invalid value in this situation.");
+                }
+
+                @Override
+                public void reportAmbiguity(Parser parser, DFA dfa, int i, int i1, boolean bln, BitSet bitset, ATNConfigSet atncs) {
+                }
+
+                @Override
+                public void reportAttemptingFullContext(Parser parser, DFA dfa, int i, int i1, BitSet bitset, ATNConfigSet atncs) {
+                }
+
+                @Override
+                public void reportContextSensitivity(Parser parser, DFA dfa, int i, int i1, int i2, ATNConfigSet atncs) {
+                }
+            });
+            while (true) {
+                Token token = lexer.nextToken();
+                if (token.getType() == TOMLAntlrLexer.EOF) {
+                    int tokenIndex = token.getStopIndex();
+                    if (tokenIndex != toParse.length() - 1) {
+                        System.out.format("Error parsing. token stop %d input max %d%n", tokenIndex, toParse.length() - 1);
+                    }
+                    break;
+                }
+                // Set to true to dump lexer tokens
+                boolean debug = false;
+                if (debug) {
+                    String tokenName = TOMLAntlrLexer.VOCABULARY.getSymbolicName(token.getType());
+                    int line = token.getLine();
+                    int column = token.getCharPositionInLine();
+                    String text = token.getText().replace('\r', '?').replace('\n', '?');
+                    System.out.format("%3d:%3d %5d-%5d-%s (%s)%n", line, column, token.getStartIndex(), token.getStopIndex(), tokenName, text);
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/test/resources/net/vieiro/toml/toml-lexer-test.toml
+++ b/src/test/resources/net/vieiro/toml/toml-lexer-test.toml
@@ -1,0 +1,120 @@
+#
+# This is a (possibly invalid) TOML document with all datatypes.
+# It's used to test the Lexer
+#
+str1 = "I'm a string."
+str2 = "You can \"quote\" me."
+str3 = "Name\tJos\u00E9\nLoc\tSF."
+
+str1 = """
+Roses are red
+Violets are blue"""
+
+str2 = """\
+  The quick brown \
+  fox jumps over \
+  the lazy dog.\
+  """
+
+# integers
+int1 = +99
+int2 = 42
+int3 = 0
+int4 = -17
+
+# hexadecimal with prefix `0x`
+hex1 = 0xDEADBEEF
+hex2 = 0xdeadbeef
+hex3 = 0xdead_beef
+
+# octal with prefix `0o`
+oct1 = 0o01234567
+oct2 = 0o755
+
+# binary with prefix `0b`
+bin1 = 0b11010110
+
+# fractional
+float1 = +1.0
+float2 = 3.1415
+float3 = -0.01
+
+# exponent
+float4 = 5e+22
+float5 = 1e06
+float6 = -2E-2
+
+# both
+float7 = 6.626e-34
+
+# separators
+float8 = 224_617.445_991_228
+
+# infinity
+infinite1 = inf # positive infinity
+infinite2 = +inf # positive infinity
+infinite3 = -inf # negative infinity
+
+# not a number
+not1 = nan
+not2 = +nan
+not3 = -nan
+
+path = 'C:\Users\nodejs\templates'
+path2 = '\\User\admin$\system32'
+quoted = 'Tom "Dubs" Preston-Werner'
+regex = '<\i\c*\s*>'
+
+lines = '''
+The first newline is
+trimmed in raw strings.
+All other whitespace
+is preserved.
+'''
+
+# offset datetime
+odt1 = 1979-05-27T07:32:00Z
+odt2 = 1979-05-27T00:32:00-07:00
+odt3 = 1979-05-27T00:32:00.999999-07:00
+
+# local datetime
+ldt1 = 1979-05-27T07:32:00
+ldt2 = 1979-05-27T00:32:00.999999
+
+# local date
+ld1 = 1979-05-27
+
+# local time
+lt1 = 07:32:00
+lt2 = 00:32:00.999999
+
+integers = [ 1, 2, 3 ]
+colors = [ "red", "yellow", "green" ]
+nested_arrays_of_ints = [ [ 1, 2 ], [3, 4, 5] ]
+nested_mixed_array = [ [ 1, 2 ], ["a", "b", "c"] ]
+string_array = [ "all", 'strings', """are the same""", '''type''' , ]
+
+# Mixed-type arrays are allowed
+numbers = [ 0.1, 0.2, 0.5, 1, 2, 5 ]
+contributors = [
+  "Foo Bar <foo@example.com>",
+  { name = "Baz Qux", email = "bazqux@example.com", url = "https://example.com/bazqux" }
+]
+
+
+[dog."tater.man"]
+type.name = "pug"
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]  # empty table within the array
+
+[[products]]
+name = "Nail"
+sku = 284758393
+
+color = "gray"
+
+"https://www.google.com


### PR DESCRIPTION
- Changed versioning scheme to:
    - Major: antlr version (for instance, `13` means `Antlr 4.13.X`
    - Minor: toml-java grammar version.
    - Patch: bug fixes
- The lexer now detects incomplete tokens and properly reports them with token `INVALID_VALUE`.
    - This is useful for the NetBeans Antlr bridge.
- toml-java runs 555 unit tests.
