### PR TITLE
Fix javadoc publishing after plugin update

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Javadoc
-        uses: MathieuSoysal/Javadoc-publisher.yml@v2.4.0
+        uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc


### PR DESCRIPTION
The maven javadoc plugin moved the default output folder for the javadoc. To acommodate for that the publishing workflow needs to be updated.

3.6.0 output directory: $basedir/target/site/apidocs
3.12.0 output directory: $basedir/target/reports/apidocs

With new versions autodetection was improved and directory could be overridden if necessary.